### PR TITLE
fix: opensearch package name for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,7 @@
       "allowedVersions": "<=7.2"
     },
     {
-      "matchPackageNames": ["opensearch"],
+      "matchPackageNames": ["opensearchproject/opensearch"],
       "allowedVersions": "<=2.12"
     },
     {

--- a/update-dependency-version.sh
+++ b/update-dependency-version.sh
@@ -33,7 +33,7 @@ setVersion "MariaDB" "mariadb" $line_number
 setVersion "PHP" "php" $line_number
 setVersion "nginx" "nginx" $line_number
 setVersion "Redis" "redis" $line_number
-setVersion "OpenSearch" "opensearch" $line_number
+setVersion "OpenSearch" "opensearchproject/opensearch" $line_number
 setVersion "Composer" "composer" $line_number
 
 


### PR DESCRIPTION
This fixes the package name for Renovate.